### PR TITLE
New links and small refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,48 +7,66 @@ Awesome list of data export pages/tools for most common online services
 * [Search-engines](#search-engines)
 * [Social networks](#social-networks)
 * [Messengers](#messengers)
-* [Business Tools](#business-tools)
+* [Business tools](#business-tools)
 * [Developer tools and services](#developer-tools-and-services)
+* [Password managers](#password-managers)
+* [Blogging](#blogging)
 * [Sport](#sport)
 * [Other services](#other-services)
 
 ## Search Engines
 
-* [Google](https://takeout.google.com) - Google Takeout, online Google tool to request your personal data collected by any Google service
-* [Microsoft](https://account.microsoft.com/privacy/activity-history?view=voice) - export your data from Microsoft services, including search
+* [Google](https://takeout.google.com) - Google Takeout is an online Google service to request your personal data collected by any Google service
+* [Microsoft](https://account.microsoft.com/privacy/activity-history?view=voice) - export your data from Microsoft services including search history
 * [Yandex](https://passport.yandex.ru/profile/data) - get all your data from all of Yandex services
 * [Yahoo](https://help.yahoo.com/kb/find-download-data-sln28671.html) - view and manage data associated with your account
 
 ## Social Networks
 
-* [Facebook](https://www.facebook.com/dyi/) - "Download your information" service, allows to download all your data from Facebook
-* [Twitter](https://twitter.com/settings/download_your_data) - instruction how to get archive of all your tweets from Twitter
-* [Vkontakte](https://vk.com/data_protection) - service to request all your data from Vkontakte, Russian most popular social network
+* [Facebook](https://www.facebook.com/dyi/) - "Download your information" service allows you to download all your data from Facebook
+* [Twitter](https://twitter.com/settings/download_your_data) - instruction about how to get archive of all your tweets from Twitter
+* [VK](https://vk.com/data_protection) - service to request all your data from Vkontakte, most popular social network in Russia and CIS countries
 * [LinkedIn](https://www.linkedin.com/psettings/member-data) - export your LinkedIn data
 * [Instagram](https://www.instagram.com/download/request/) - export your Instagram data
 
 ## Messengers
 
-* Telegram - open desktop app, use 'Settings', next "Advanced", and click "Export Telegram Data"
+* [Telegram](https://telegram.org/blog/export-and-more) - open desktop app, use "Settings" > "Advanced" > "Export Telegram Data"
+* [Viber](https://help.viber.com/en/article/request-review-and-delete-your-data-on-viber) - an article about how to request, review or delete your data from Viber
+* [Whatsapp](https://faq.whatsapp.com/general/account-and-profile/how-to-request-your-account-information/?lang=en) - request your account info excluding chat history which must be exported separately ([learn more](https://faq.whatsapp.com/android/chats/how-to-save-your-chat-history/?lang=en))
 
 ## Business tools
 
 * [Slack](https://slack.com/intl/en-fr/help/articles/201658943) - export Slack data 
 * [Notion](https://www.notion.so/help/export-your-content#export-your-entire-workspace) - simple guide on how to export whole workspace
 * [Mailchimp](https://mailchimp.com/help/export-back-up-data/) - export and backup your data from Mailchimp account
+* [Trello](https://trello.com) - open profile, click "Settings" and use link "Export personal data"
+* [Miro](https://help.miro.com/hc/en-us/articles/360017572754-How-to-export-your-board) - export your board in several ways or [make an importable backup](https://help.miro.com/hc/en-us/articles/360017572774) of a board
 
 ## Developer tools and services
 
-* [Github](https://docs.github.com/en/get-started/privacy-on-github/requesting-an-archive-of-your-personal-accounts-data) - requesting an archive of your personal account’s data
+* [GitHub](https://docs.github.com/en/get-started/privacy-on-github/requesting-an-archive-of-your-personal-accounts-data) - requesting an archive of your personal account’s data
+* [Postman](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/#exporting-postman-data) - backup your collections, environments, etc. Also they have [this useful section](https://www.postman.com/legal/privacy-policy/#how-to-access-and-control-your-information) in privacy policy about how to access and control your information
+
+## Password managers
+
+* [1Password](https://support.1password.com/export/) - you can export your data if you want to move it to a different app
+* [Bitwarden](https://bitwarden.com/help/export-your-data/) - export whole vault
+* [LastPass](https://support.logmeininc.com/lastpass/help/export-your-passwords-and-secure-notes-lp040004) - help section about exporting passwords and other saved data
+
+## Blogging
+
+* [Medium](https://help.medium.com/hc/en-us/articles/115004745787-Export-your-account-data) - export your account data
+* [Wordpress](https://wordpress.com/support/export/) - download your blog content and media files
+* [Blogger](https://support.google.com/blogger/answer/41387?hl=en) - how to backup content (including comments) and current theme
 
 ## Sport
 
-[Strava](https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export) - exporting your Strava data and bulk export
-
+* [Strava](https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export) - exporting your Strava data and bulk export
+* [Garmin](https://support.garmin.com/en-US/?faq=q22kMdCbU23NUT2Wmspz16) - export your profile data, fitness activities, order history and information from Garmin applications
 
 ## Other services
 
 * [Flickr](https://www.flickr.com/account/) - find "Your Flickr Data" part of the webpage and request your data. It will be sent to your linked email.
 * [Etsy](https://www.etsy.com/your/account/privacy) - use "Request your data for download" button to get data as CSV and JSON files
 * [Pinboard](https://pinboard.in/settings/backup) - export your Pinboard bookmarks
-* [Trello](https://trello.com) - open profile, click "Settings" and use link "Export personal data"


### PR DESCRIPTION
New: 
* "Password managers" section with 1Password, Bitwarden and LastPass;
* "Blogging" section with Wordpress, Blogger and Medium;
* Garmin in "Sport" section;
* Viber and Whatsapp in "Messengers" section;
* Miro in "Business tools";
* Postman in "Developer tools and services".

Changed:
* Telegram: added link to blog post where this feature was introduced;
* Trello: moved from "Other services" section to "Business tools";
* Vkontakte: renamed to VK;
* some typos was fixed across the file.